### PR TITLE
Logging for dev and prod environments.

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -4,6 +4,7 @@ BOT_NAME=mybotname
 BOT_TOKEN=123456:Your-TokEn_ExaMple
 ADMINS=123456,654321
 USE_REDIS=False
+ENVIRONMENT=dev
 
 #PG_CONTAINER_NAME=pg_database
 #POSTGRES_USER=someusername

--- a/.env.dist
+++ b/.env.dist
@@ -4,6 +4,7 @@ BOT_NAME=mybotname
 BOT_TOKEN=123456:Your-TokEn_ExaMple
 ADMINS=123456,654321
 USE_REDIS=False
+# use here "prod" or "dev"
 ENVIRONMENT=dev
 
 #PG_CONTAINER_NAME=pg_database

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ venv.bak/
 .idea/
 .env
 cache/
+
+logs/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+tail_lines := 100
+
+# Makefile for tailing logs with a parameter for the number of lines
+# usage: "make show-logs N=20", where N is the number of lines to tail.
+#         ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
+ifeq ($(strip $(N)),)
+    # No COUNT parameter provided, using default value
+    tail_cmd := tail -n $(tail_lines) -f
+else
+    # COUNT parameter provided, using it as the line count
+    tail_cmd := tail -n $(N) -f
+endif
+
+.PHONY: tail
+
+show-logs:
+	$(tail_cmd) logs/logs.txt

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
+import pathlib
 
-import betterlogging as bl
 from aiogram import Bot, Dispatcher
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.fsm.storage.redis import RedisStorage, DefaultKeyBuilder
@@ -43,10 +43,8 @@ def setup_logging(config: Config):
     Set up logging configuration for the application.
 
     The function sets up logging for production and development environments.
-    If the environment is development, the function will add a filter to the logger that will create a full path
-    to the file where the log record was created. This is done to make it easier to find the place where the log
-    record was created.
-    Otherwise, the function will set up a colorized logging configuration using the betterlogging library.
+    If the environment is development, the function sets up logging to the console with the package path filter.
+    Otherwise, the function sets up logging to the file.
 
     Args:
         config (Config): The configuration object.
@@ -57,22 +55,42 @@ def setup_logging(config: Config):
     Example usage:
         setup_logging(config)
     """
-    logger = logging.getLogger("__name__")
-    log_level = logging.INFO
+    logger = logging.getLogger(__name__)
 
     if config.environment == "dev":
+        # note - didn't find a way to set the filter in BasicConfig, so I used loggerDict
         package_filter = LoggingPackagePathFilter()
-        logger.addFilter(package_filter)
-        log_format = "%(pathname)s:%(lineno)s: %(message)s"
+        loggers_names = [name for name in logging.root.manager.loggerDict] + ["root"]
+        for logger_name in loggers_names:
+            logging.getLogger(logger_name).addFilter(package_filter)
+
+        # setup logging configuration for dev environment with StreamHandler
+        log_format = "%(pathname)s:%(lineno)s [%(name)s]: %(message)s"
+        formatter = logging.Formatter(log_format)
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        handlers = [handler]
     else:
-        bl.basic_colorized_config(level=log_level)
+        # define logs directory and path to logs file and create logs directory if it does not exist
+        logs_directory = pathlib.Path("logs")
+        logs_path = logs_directory / "logs.txt"
+        pathlib.Path(logs_directory).mkdir(parents=True, exist_ok=True)
+
+        # setup logging configuration for prod environment with FileHandler
+        handler = logging.FileHandler(logs_path, mode="a")
         log_format = "%(filename)s:%(lineno)d #%(levelname)-8s [%(asctime)s] - %(name)s - %(message)s"
-        logging.getLogger("aiogram").setLevel(logging.WARNING)  # reduce aiogram logging
+        formatter = logging.Formatter(log_format)
+        handler.setFormatter(formatter)
+        handlers = [handler]
+        # reduce aiogram logging level
+        logging.getLogger("aiogram").setLevel(logging.WARNING)
 
     logging.basicConfig(
-            level=log_level,
-            format=log_format,
+        level=logging.INFO,
+        format=log_format,
+        handlers=handlers,
     )
+
     logger.info("Starting bot in %s environment", config.environment)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 aiogram==3.0.0b7
 environs~=9.0
 redis
-betterlogging
 
 # # For enabling api:
 # backoff

--- a/tgbot/config.py
+++ b/tgbot/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Literal
 
 from environs import Env
 
@@ -168,6 +168,7 @@ class Config:
 
     tg_bot: TgBot
     misc: Miscellaneous
+    environment: Literal["dev", "prod"]
     db: Optional[DbConfig] = None
     redis: Optional[RedisConfig] = None
 
@@ -187,6 +188,7 @@ def load_config(path: str = None) -> Config:
 
     return Config(
         tg_bot=TgBot.from_env(env),
+        environment=env.str("ENVIRONMENT", "dev"),
         # db=DbConfig.from_env(env),
         # redis=RedisConfig.from_env(env),
         misc=Miscellaneous(),

--- a/tgbot/misc/logging.py
+++ b/tgbot/misc/logging.py
@@ -5,6 +5,16 @@ import os
 class LoggingPackagePathFilter(logging.Filter):
     """
     Filter add relative path to the log record.
+    The filter create a short path instead of fullpath.
+
+    Logs example:
+        /home/user/project/file.py -> /file.py
+
+    Usage example:
+        logger = logging.getLogger(__name__)
+        package_filter = LoggingPackagePathFilter()
+        logger.addFilter(package_filter)
+
     """
     # taken from
     # https://stackoverflow.com/questions/52582458/how-can-i-include-the-relative-path-to-a-module-in-a-python-logging-statement

--- a/tgbot/misc/logging.py
+++ b/tgbot/misc/logging.py
@@ -1,0 +1,13 @@
+import logging
+import os
+
+
+class LoggingPackagePathFilter(logging.Filter):
+    """
+    Filter add relative path to the log record.
+    """
+    # taken from
+    # https://stackoverflow.com/questions/52582458/how-can-i-include-the-relative-path-to-a-module-in-a-python-logging-statement
+    def filter(self, record):
+        record.pathname = record.pathname.replace(os.getcwd(), "")
+        return True


### PR DESCRIPTION
### Changes
Set up logging configuration for prod and dev environments.

1) In the **prod** environment, the code will handle logs with FileHandler.
2) In the **dev** environment the code will handle logs with ConsoleHandler and show the short practical clickable path to log record.
3) Created Makefile with a shortcut that shows logs from the logs file.
4) Removed the` betterlogging` library from the `requirements.txt` file.


Usage example for **dev**
https://im.ezgif.com/tmp/ezgif-1-abd45868ae.gif