### PR TITLE
Update users.py

### DIFF
--- a/infrastructure/database/repo/users.py
+++ b/infrastructure/database/repo/users.py
@@ -24,7 +24,7 @@ class UserRepo(BaseRepo):
         :return: User object, None if there was an error while making a transaction.
         """
 
-        insert_stmt = select(User).from_statement(
+        insert_stmt = (
             insert(User)
             .values(
                 user_id=user_id,
@@ -32,7 +32,6 @@ class UserRepo(BaseRepo):
                 full_name=full_name,
                 language=language,
             )
-            .returning(User)
             .on_conflict_do_update(
                 index_elements=[User.user_id],
                 set_=dict(
@@ -40,8 +39,9 @@ class UserRepo(BaseRepo):
                     full_name=full_name,
                 ),
             )
+            .returning(User)
         )
-        result = await self.session.scalars(insert_stmt)
+        result = await self.session.execute(insert_stmt)
 
         await self.session.commit()
-        return result.first()
+        return result.scalar_one()


### PR DESCRIPTION
Refactoring of the User insertion process: now the insert operation will update the User entry if a conflict occurs (if a User with the provided user_id already exists). The updated attributes are username and full_name. The use of .scalar_one() method from SQLAlchemy to return exactly one User model instance after the insert operation or raise an error if no result is found or if multiple results are found. This ensures the correctness of our function in situations where the insertion process modifies the state of an existing User. Improved project code readability and database operation efficiency through more granular SQLAlchemy methods.