### PR TITLE
Refactor Base Model.

### DIFF
--- a/infrastructure/database/models/base.py
+++ b/infrastructure/database/models/base.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from sqlalchemy.dialects.postgresql import TIMESTAMP
 from sqlalchemy.ext.declarative import declared_attr
@@ -22,4 +22,5 @@ class TableNameMixin:
 
 
 class TimestampMixin:
-    created_at: Mapped[datetime] = mapped_column(TIMESTAMP, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP, server_default=func.now())


### PR DESCRIPTION
### In this PR I have fixed import datetime module in order to use properly datetime type instead of using datetime module as type of "created_at" column.